### PR TITLE
Added entrypoint field

### DIFF
--- a/user_config.go
+++ b/user_config.go
@@ -145,6 +145,9 @@ type InstanceConfig struct {
 	// tags. E.g. dockerfile/redis:latest.
 	Image dockertypes.DockerImage `json:"image" description:"Name of a docker image to use when running a container. The image includes tags"`
 
+	// If given, overwrite the entrypoint of the docker image.
+	EntryPoint string `json:"entrypoint,omitempty" description:"If given, overwrite the entrypoint of the docker image"`
+
 	// List of ports a service exposes. E.g. 6379/tcp
 	Ports []dockertypes.DockerPort `json:"ports,omitempty" description:"List of ports this component exposes"`
 

--- a/user_config_env_test.go
+++ b/user_config_env_test.go
@@ -160,8 +160,8 @@ func TestUnmarshalEnvFullAppUpperCase(t *testing.T) {
 	}
 
 	got := fmt.Sprintf("%v", appConfig)
-	expected := "{envtest map[] [{envtest-service map[] <nil> [{env-struct <nil> {busybox [] [KEY=env-array] [] [] map[] []}} {env-struct <nil> {busybox [] [KEY=env-struct] [] [] map[] []}}]}]}"
+	expected := "{envtest map[] [{envtest-service map[] <nil> [{env-struct <nil> {busybox  [] [KEY=env-array] [] [] map[] []}} {env-struct <nil> {busybox  [] [KEY=env-struct] [] [] map[] []}}]}]}"
 	if got != expected {
-		t.Fatalf("Invalid result: got %s, expected %s", got, expected)
+		t.Fatalf("Invalid result: got \n%s\nexpected\n%s", got, expected)
 	}
 }


### PR DESCRIPTION
This PR adds the entrypoint field. This will be used so users can overwrite their docker entrypoint from the docker image, if needed.

Related:
- https://github.com/giantswarm/app-service/pull/182

ping @ewoutp
