### PR TITLE
user-config: Add STOPPING state

### DIFF
--- a/status.go
+++ b/status.go
@@ -7,25 +7,35 @@ const (
 	STATUS_DOWN     Status = "down"
 	STATUS_STARTING Status = "starting"
 	STATUS_UP       Status = "up"
+	STATUS_STOPPING Status = "stopping"
 )
 
 func (s *Status) String() string {
 	return string(*s)
 }
 
+var (
+	// StatusOrder is used by AggregateStatus to determine the higher status.
+	// Lower Index wins over higher Index
+	StatusOrder = []Status{
+		STATUS_FAILED,
+		STATUS_DOWN,
+		STATUS_STARTING,
+		STATUS_STOPPING,
+		STATUS_UP,
+	}
+)
+
 // AggregateStatus returns the 'higher' of the two status, given the following order:
-//  ok < starting < down < failed
+//  ok < stopping < starting < down < failed
 func AggregateStatus(status1, status2 Status) Status {
-	if status1 == STATUS_FAILED || status2 == STATUS_FAILED {
-		return STATUS_FAILED
+
+	for _, nextStatus := range StatusOrder {
+		if status1 == nextStatus || status2 == nextStatus {
+			return nextStatus
+		}
 	}
-	if status1 == STATUS_DOWN || status2 == STATUS_DOWN {
-		return STATUS_DOWN
-	}
-	if status1 == STATUS_STARTING || status2 == STATUS_STARTING {
-		return STATUS_STARTING
-	}
-	return STATUS_UP
+	panic("Unknown status: " + status1 + ", " + status2)
 }
 
 // Inactive means an app is failed or down.
@@ -33,14 +43,10 @@ func IsStatusInactive(status Status) bool {
 	return status == STATUS_FAILED || status == STATUS_DOWN
 }
 
-// Active means starting or up.
-func IsStatusActive(status Status) bool {
-	return status == STATUS_STARTING || status == STATUS_UP
-}
-
 // IsStatusFinal returns whether the given status is a final status and should not change upon itself.
-// E.g. A unit with a status STARTING will after some time either switch to UP or FAILED, thus the state is not final.
-// Final states are UP or FAILED.
+// E.g. A unit with a status STARTING will after some time either switch to UP or FAILED,
+// thus the state is not final.
+// Final states are UP, DOWN or FAILED.
 func IsStatusFinal(status Status) bool {
-	return status == STATUS_FAILED || status == STATUS_UP
+	return status == STATUS_FAILED || status == STATUS_UP || status == STATUS_DOWN
 }

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,34 @@
+package userconfig
+
+import "testing"
+
+func TestAggregateStatus(t *testing.T) {
+	table := []struct {
+		Status1        Status
+		Status2        Status
+		ExpectedStatus Status
+	}{
+		{STATUS_DOWN, STATUS_DOWN, STATUS_DOWN},
+		{STATUS_UP, STATUS_UP, STATUS_UP},
+		{STATUS_UP, STATUS_STARTING, STATUS_STARTING},
+		{STATUS_UP, STATUS_STOPPING, STATUS_STOPPING},
+		{STATUS_DOWN, STATUS_STOPPING, STATUS_DOWN},
+		{STATUS_FAILED, STATUS_STARTING, STATUS_FAILED},
+		{STATUS_FAILED, STATUS_DOWN, STATUS_FAILED},
+		{STATUS_DOWN, STATUS_UP, STATUS_DOWN},
+	}
+
+	for index, testEntry := range table {
+		agg := AggregateStatus(testEntry.Status1, testEntry.Status2)
+
+		if agg != testEntry.ExpectedStatus {
+			t.Errorf("%02d: AggregateStatus(%v, %v) = %v, expected %v\n",
+				index,
+				testEntry.Status1,
+				testEntry.Status2,
+				agg,
+				testEntry.ExpectedStatus,
+			)
+		}
+	}
+}


### PR DESCRIPTION
I would like to fix the fact that we report stopping as starting in our current CLI.

For this I would like to rollout support for a STOPPING state in the CLI ASAP.  We can then roll this out in the app-service afterwards so the clients don't suddenly break because they see `stopping` in the response.

CLI: https://github.com/giantswarm/cli/pull/216
