### PR TITLE
user-config: Normalize all volume paths in the validator to match /foo with /foo/

### DIFF
--- a/user_config_validator.go
+++ b/user_config_validator.go
@@ -3,6 +3,7 @@ package userconfig
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -398,9 +399,9 @@ func (cc *ComponentConfig) validateUniqueMountPoints(service *ServiceConfig) err
 	for _, v := range cc.Volumes {
 		var paths []string
 		if v.Path != "" {
-			paths = []string{v.Path}
+			paths = []string{normalizeFolder(v.Path)}
 		} else if v.VolumeFrom != "" {
-			paths = []string{v.VolumePath}
+			paths = []string{normalizeFolder(v.VolumePath)}
 		} else if v.VolumesFrom != "" {
 			other := service.findComponent(v.VolumesFrom)
 			if other == nil {
@@ -441,9 +442,9 @@ func (cc *ComponentConfig) getAllMountPoints(service *ServiceConfig, visitedComp
 	mountPoints := []string{}
 	for _, v := range cc.Volumes {
 		if v.Path != "" {
-			mountPoints = append(mountPoints, v.Path)
+			mountPoints = append(mountPoints, normalizeFolder(v.Path))
 		} else if v.VolumePath != "" {
-			mountPoints = append(mountPoints, v.VolumePath)
+			mountPoints = append(mountPoints, normalizeFolder(v.VolumePath))
 		} else if v.VolumesFrom != "" {
 			other := service.findComponent(v.VolumesFrom)
 			if other == nil {
@@ -609,4 +610,16 @@ func (dc *DependencyConfig) getAlias(serviceName string) string {
 		alias = depComponent
 	}
 	return alias
+}
+
+// normalizeFolder removes any trailing path separator from the given path.
+func normalizeFolder(path string) string {
+	if path == "" {
+		return ""
+	}
+	l := len(path)
+	if os.IsPathSeparator(path[l-1]) {
+		path = path[:l-1]
+	}
+	return path
 }

--- a/user_config_validator_pod_test.go
+++ b/user_config_validator_pod_test.go
@@ -472,6 +472,29 @@ var _ = Describe("user config pod validator", func() {
 
 		})
 
+		Describe("parsing invalid volume configs, duplicate volume via different postfixes", func() {
+			var err error
+
+			BeforeEach(func() {
+				appConfig := testApp(
+					testService("session1",
+						addVols(testComponent("api", ""),
+							VolumeConfig{Path: "/xdata1", Size: VolumeSize("27 GB")},
+							VolumeConfig{Path: "/xdata1/", Size: VolumeSize("27 GB")},
+						),
+					),
+				)
+
+				err = appConfig.validate()
+			})
+
+			It("should throw error DuplicateVolumePathError", func() {
+				Expect(IsDuplicateVolumePath(err)).To(BeTrue())
+				Expect(err.Error()).To(Equal(`Cannot parse app config. Duplicate volume '/xdata1' found in component 'api'.`))
+			})
+
+		})
+
 		Describe("parsing invalid volume configs in pods, duplicate volume via volumes-from", func() {
 			var err error
 


### PR DESCRIPTION
fixes the user-config validation part of giantswarm/app-service#265

This change in the validator now gives a duplicate volume error for '/foo' and '/foo/'
