### PR TITLE
user-config: Added optional application name to v2 app definition

### DIFF
--- a/app_name.go
+++ b/app_name.go
@@ -1,0 +1,41 @@
+package userconfig
+
+import (
+	"regexp"
+)
+
+var (
+	appNameRegExp = regexp.MustCompile("^[a-zA-Z0-9]{1}[a-z0-9A-Z_-]{0,99}$")
+)
+
+type AppName string
+
+// String returns a string version of the given AppName.
+func (an AppName) String() string {
+	return string(an)
+}
+
+// Empty returns true if the given AppName is empty, false otherwise.
+func (an AppName) Empty() bool {
+	return an == ""
+}
+
+// Equals returns true if the given AppName is equal to the other
+// given application name, false otherwise.
+func (an AppName) Equals(other AppName) bool {
+	return an == other
+}
+
+// Validate checks that the given NodeName is a valid NodeName.
+func (an AppName) Validate() error {
+	if an.Empty() {
+		return maskf(InvalidAppNameError, "application name must not be empty")
+	}
+
+	anStr := an.String()
+	if !appNameRegExp.MatchString(anStr) {
+		return maskf(InvalidAppNameError, "application name '%s' must match regexp: %s", anStr, appNameRegExp)
+	}
+
+	return nil
+}

--- a/app_name_test.go
+++ b/app_name_test.go
@@ -1,0 +1,71 @@
+package userconfig_test
+
+import (
+	"testing"
+
+	"github.com/giantswarm/user-config"
+)
+
+func TestValidAppNames(t *testing.T) {
+	list := map[string]string{
+		"a":        "app name should be allowed to be normal single character",
+		"x":        "app name should be allowed to be normal single character",
+		"0":        "app name should be allowed to be normal single character",
+		"3":        "app name should be allowed to be normal single character",
+		"wjehfg":   "app name should be allowed to contain normal words",
+		"wj_eh-fg": "app name should be allowed to contain dashes and underscores",
+	}
+
+	for name, reason := range list {
+		appName := userconfig.AppName(name)
+		err := appName.Validate()
+
+		if err != nil {
+			t.Fatalf("valid app name '%s' detected to be invalid: %s", name, reason)
+		}
+	}
+}
+
+func TestInvalidAppNames(t *testing.T) {
+	list := map[string]string{
+		"":      "app name must not be empty",
+		"-":     "app name must not start with special chars",
+		"-/-/-": "app name must not start contain slashes",
+		"-x":    "app name must not start with special chars",
+		"&0":    "app name must not start with special chars",
+		"$3":    "app name must not start with special chars",
+		"()wjehfg/skdjcsd/jshg": "app name must not start with special chars",
+		"a ": "app name parts must not contain spaces",
+	}
+
+	for name, reason := range list {
+		appName := userconfig.AppName(name)
+		err := appName.Validate()
+
+		if err == nil {
+			t.Fatalf("invalid app name '%s' not detected: %s", name, reason)
+		}
+		if !userconfig.IsInvalidAppName(err) {
+			t.Fatalf("expected error to be InvalidAppNameError")
+		}
+	}
+}
+
+func TestAppNameEmpty(t *testing.T) {
+	list := []struct {
+		Name   string
+		Result bool
+	}{
+		{"", true},
+		{"a", false},
+		{"a/b", false},
+	}
+
+	for _, test := range list {
+		name := userconfig.AppName(test.Name)
+		result := name.Empty()
+		if test.Result != result {
+			t.Fatalf("Test %v failed: got '%v', expected '%v'", test, result, test.Result)
+		}
+	}
+}

--- a/error.go
+++ b/error.go
@@ -22,6 +22,7 @@ var (
 	InvalidAppDefinitionError     = errgo.New("invalid app definition")
 	InvalidNodeDefinitionError    = errgo.New("invalid node definition")
 	InvalidImageDefinitionError   = errgo.New("invalid image definition")
+	InvalidAppNameError           = errgo.New("invalid application name")
 	InvalidNodeNameError          = errgo.New("invalid node name")
 	InvalidPodConfigError         = errgo.New("invalid pod configuration")
 	NodeNotFoundError             = errgo.New("node not found")
@@ -48,6 +49,7 @@ var (
 		IsInvalidAppDefinition,
 		IsInvalidNodeDefinition,
 		IsInvalidImageDefinition,
+		IsInvalidAppName,
 		IsInvalidNodeName,
 		IsNodeNotFound,
 		IsInternal,
@@ -141,6 +143,10 @@ func IsInvalidNodeDefinition(err error) bool {
 
 func IsInvalidImageDefinition(err error) bool {
 	return errgo.Cause(err) == InvalidImageDefinitionError
+}
+
+func IsInvalidAppName(err error) bool {
+	return errgo.Cause(err) == InvalidAppNameError
 }
 
 func IsInvalidNodeName(err error) bool {

--- a/v2_user_config.go
+++ b/v2_user_config.go
@@ -9,7 +9,7 @@ import (
 
 type V2AppDefinition struct {
 	// Optional application name
-	AppName string `json:"name,omitempty"`
+	AppName AppName `json:"name,omitempty"`
 
 	// Nodes
 	Nodes NodeDefinitions `json:"nodes"`
@@ -68,6 +68,12 @@ func (ad *V2AppDefinition) Validate(valCtx *ValidationContext) error {
 		return maskf(InvalidAppDefinitionError, "nodes must not be empty")
 	}
 
+	if !ad.AppName.Empty() {
+		if err := ad.AppName.Validate(); err != nil {
+			return mask(err)
+		}
+	}
+
 	if err := ad.Nodes.validate(valCtx); err != nil {
 		return mask(err)
 	}
@@ -118,8 +124,8 @@ func V2AppName(b []byte) (string, error) {
 // It is does not exist, it generates an app name.
 func (ad *V2AppDefinition) Name() (string, error) {
 	// Is a name specified?
-	if ad.AppName != "" {
-		return ad.AppName, nil
+	if !ad.AppName.Empty() {
+		return ad.AppName.String(), nil
 	}
 
 	// No name is specified, generate one

--- a/v2_user_config_test.go
+++ b/v2_user_config_test.go
@@ -205,7 +205,7 @@ func TestV2AbsentAppName(t *testing.T) {
 func TestV2SpecifiedAppName(t *testing.T) {
 	a := V2ExampleDefinition()
 	expectedName := "nice-he"
-	a.AppName = expectedName
+	a.AppName = userconfig.AppName(expectedName)
 	name, err := a.Name()
 	if err != nil {
 		t.Fatalf("Name failed: %#v", err)


### PR DESCRIPTION
This change adds support for an (optional) `name` in a V2 app definition.

See #33
