### PR TITLE
allow dots in service names

### DIFF
--- a/app_name.go
+++ b/app_name.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	appNameRegExp = regexp.MustCompile("^[a-zA-Z0-9]{1}[a-z0-9A-Z_-]{0,99}$")
+	appNameRegExp = regexp.MustCompile("^[a-zA-Z0-9]{1}[a-z0-9A-Z_.-]{0,99}$")
 )
 
 type AppName string

--- a/app_name_test.go
+++ b/app_name_test.go
@@ -8,12 +8,13 @@ import (
 
 func TestValidAppNames(t *testing.T) {
 	list := map[string]string{
-		"a":        "app name should be allowed to be normal single character",
-		"x":        "app name should be allowed to be normal single character",
-		"0":        "app name should be allowed to be normal single character",
-		"3":        "app name should be allowed to be normal single character",
-		"wjehfg":   "app name should be allowed to contain normal words",
-		"wj_eh-fg": "app name should be allowed to contain dashes and underscores",
+		"a":           "app name should be allowed to be normal single character",
+		"x":           "app name should be allowed to be normal single character",
+		"0":           "app name should be allowed to be normal single character",
+		"3":           "app name should be allowed to be normal single character",
+		"wjehfg":      "app name should be allowed to contain normal words",
+		"wj_eh-fg":    "app name should be allowed to contain dashes and underscores",
+		"foo-bar.com": "app name should be allowed to contain dashes and dots",
 	}
 
 	for name, reason := range list {
@@ -29,13 +30,17 @@ func TestValidAppNames(t *testing.T) {
 func TestInvalidAppNames(t *testing.T) {
 	list := map[string]string{
 		"":      "app name must not be empty",
+		" ":     "app name must not be empty space",
 		"-":     "app name must not start with special chars",
+		".":     "app name must not start with special chars",
 		"-/-/-": "app name must not start contain slashes",
 		"-x":    "app name must not start with special chars",
 		"&0":    "app name must not start with special chars",
 		"$3":    "app name must not start with special chars",
 		"()wjehfg/skdjcsd/jshg": "app name must not start with special chars",
-		"a ": "app name parts must not contain spaces",
+		"a ":   "app name parts must not contain spaces",
+		" a":   "app name parts must not start with spaces",
+		".foo": "app name parts must not start with dots",
 	}
 
 	for name, reason := range list {


### PR DESCRIPTION
There is this error when deleting old services.

```
DEBUG: [{/home/vagrant/projects/giantswarm/swarmctl/.gobuild/src/github.com/giantswarm/swarmctl/cli/delete_old_apps.go:105: } {/home/vagrant/projects/giantswarm/swarmctl/.gobuild/src/github.com/giantswarm/app-service/service/app-service/app_service.go:264: } {/home/vagrant/projects/giantswarm/swarmctl/.gobuild/src/github.com/giantswarm/app-service/service/app-service/repository/app_repository_etcd.go:108: } {/home/vagrant/projects/giantswarm/swarmctl/.gobuild/src/github.com/giantswarm/user-config/v2_user_config.go:42: } {/home/vagrant/projects/giantswarm/swarmctl/.gobuild/src/github.com/giantswarm/user-config/v2_user_config.go:73: } {/home/vagrant/projects/giantswarm/swarmctl/.gobuild/src/github.com/giantswarm/user-config/app_name.go:37: } {/home/vagrant/projects/giantswarm/swarmctl/.gobuild/src/github.com/giantswarm/user-config/error.go:67: app name 'harmonielembeek.be' must match regexp: ^[a-zA-Z0-9]{1}[a-z0-9A-Z_-]{0,99}$}]
```

Talked with @ZeissS, dots should be allowed.
