### PR TITLE
Changed signal_ready to signal-ready

### DIFF
--- a/node_definition.go
+++ b/node_definition.go
@@ -35,7 +35,7 @@ type ComponentDefinition struct {
 	Pod PodEnum `json:"pod,omitempty" description:"Pod behavior of this component and its children."`
 
 	// If true, user needs to send a signal to indicate that the container is ready is should be considered running.
-	SignalReady bool `json:"signal_ready,omitempty" description:"If true, user has to notify when the component is ready."`
+	SignalReady bool `json:"signal-ready,omitempty" description:"If true, user has to notify when the component is ready."`
 }
 
 // validate performs semantic validations of this ComponentDefinition.


### PR DESCRIPTION
We want to have dashes instead of underscores.
