### PR TITLE
Add MemoryLimit field to user-config

### DIFF
--- a/bytesize.go
+++ b/bytesize.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	// ByteSizeUnits maps sthg like "kb" to 1000 or "kib" to 1024.
+	// Lookup & Keys should be lowercase.
 	// See https://en.wikipedia.org/wiki/Kibibyte
 	ByteSizeUnits = map[string]uint64{
 		"": 1, // Allow empty unit
@@ -66,8 +67,16 @@ func (b ByteSize) Equals(other ByteSize) bool {
 	return myBytes == otherBytes
 }
 
+// IsEmpty returns true if the underlying string is empty
+func (b ByteSize) IsEmpty() bool {
+	return b.String() == ""
+}
+
 // Valid returns a bool indicating whether this ByteSize value can successfully be parsed.
 func (b ByteSize) Valid() bool {
+	if b.IsEmpty() {
+		return false
+	}
 	_, err := b.Bytes()
 	return err == nil
 }
@@ -81,6 +90,7 @@ func (b ByteSize) Bytes() (uint64, error) {
 		return 0, errgo.Mask(err, errgo.Any)
 	}
 
+	unit = strings.ToLower(unit)
 	if factor, ok := ByteSizeUnits[unit]; ok {
 		return factor * value, nil
 	} else {

--- a/bytesize.go
+++ b/bytesize.go
@@ -76,7 +76,7 @@ func (b ByteSize) Valid() bool {
 // If the value of b is unparsable, an error is returned. On success, the value in bytes is returend.
 // Example: if the value contains "3 kb", 3000 will be returned.
 func (b ByteSize) Bytes() (uint64, error) {
-	value, unit, err := b.parse()
+	value, unit, err := b.Parse()
 	if err != nil {
 		return 0, errgo.Mask(err, errgo.Any)
 	}
@@ -89,7 +89,7 @@ func (b ByteSize) Bytes() (uint64, error) {
 }
 
 // parse splits b into (uint, unit, error)
-func (b ByteSize) parse() (uint64, string, error) {
+func (b ByteSize) Parse() (uint64, string, error) {
 	r := strings.NewReader(string(b))
 	scanner := bufio.NewScanner(r)
 	scanner.Split(ScanDigits)

--- a/bytesize.go
+++ b/bytesize.go
@@ -52,6 +52,20 @@ func IsInvalidByteSizeFormatUnexpectedToken(err error) bool {
 
 type ByteSize string
 
+func (b ByteSize) Equals(other ByteSize) bool {
+	myBytes, err := b.Bytes()
+	if err != nil {
+		return false
+	}
+
+	otherBytes, err := other.Bytes()
+	if err != nil {
+		return false
+	}
+
+	return myBytes == otherBytes
+}
+
 // Valid returns a bool indicating whether this ByteSize value can successfully be parsed.
 func (b ByteSize) Valid() bool {
 	_, err := b.Bytes()

--- a/bytesize.go
+++ b/bytesize.go
@@ -1,0 +1,135 @@
+package userconfig
+
+import (
+	"bufio"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/juju/errgo"
+)
+
+var (
+	// ByteSizeUnits maps sthg like "kb" to 1000 or "kib" to 1024.
+	// See https://en.wikipedia.org/wiki/Kibibyte
+	ByteSizeUnits = map[string]uint64{
+		"": 1, // Allow empty unit
+
+		"kb":  1000,
+		"k":   1000,
+		"kib": 1024,
+
+		"m":   1000 * 1000,
+		"mb":  1000 * 1000,
+		"mib": 1024 * 1024,
+
+		"g":   1000 * 1000 * 1000,
+		"gb":  1000 * 1000 * 1000,
+		"gib": 1024 * 1024 * 1024,
+
+		"t":   1000 * 1000 * 1000 * 1000,
+		"tb":  1000 * 1000 * 1000 * 1000,
+		"tib": 1024 * 1024 * 1024 * 1024,
+	}
+)
+
+type ByteSize string
+
+func (b ByteSize) Valid() bool {
+	_, err := b.Bytes()
+	return err == nil
+}
+
+func (b ByteSize) Bytes() (uint64, error) {
+	value, unit, err := b.parse()
+	if err != nil {
+		return 0, errgo.Mask(err, errgo.Any)
+	}
+
+	if factor, ok := ByteSizeUnits[unit]; ok {
+		return factor * value, nil
+	} else {
+		return 0, errgo.Newf("Unknown unit: '%s'", unit)
+	}
+}
+
+// parse splits b into (uint, unit, error)
+func (b ByteSize) parse() (uint64, string, error) {
+	r := strings.NewReader(string(b))
+	scanner := bufio.NewScanner(r)
+	scanner.Split(ScanDigits)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return 0, "", errgo.Mask(err, errgo.Any)
+		}
+		return 0, "", errgo.Newf("No digits found at begin of input")
+	}
+	digits := scanner.Text()
+
+	value, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil {
+		return 0, "", errgo.Mask(err, errgo.Any)
+	}
+
+	// Parse the input for the unit
+	scanner.Split(bufio.ScanWords)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return 0, "", errgo.Mask(err, errgo.Any)
+		}
+		return value, "", nil
+	}
+
+	unit := scanner.Text()
+
+	// Scan one more time to check for data garbage
+	if scanner.Scan() {
+		return 0, "", errgo.Newf("Unexpected token: %s", scanner.Text())
+	} else {
+		if err := scanner.Err(); err != nil {
+			return 0, "", errgo.Mask(err, errgo.Any)
+		}
+	}
+
+	return value, unit, nil
+}
+
+func (b ByteSize) String() string {
+	return string(b)
+}
+
+// ScanDigits implements bufio.SplitFunc for digits (0-9)
+func ScanDigits(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	fmt.Printf("data=%v\n", data)
+	// Skip whitespaces
+	start := 0
+	for width := 0; start < len(data); start += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[start:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+	}
+
+	fmt.Printf("1) Start=%v\n", start)
+
+	// Scan digits
+	for width, i := 0, start; i < len(data); i += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[i:])
+
+		if !unicode.IsDigit(r) {
+			fmt.Printf("2) End=%v\n", start+i)
+			return i, data[start:i], nil
+		}
+	}
+
+	if atEOF && len(data) > start {
+		return len(data), data[start:], nil
+	}
+	// Request more data.
+	return start, nil, nil
+
+}

--- a/bytesize_test.go
+++ b/bytesize_test.go
@@ -1,0 +1,47 @@
+package userconfig
+
+import (
+	"testing"
+)
+
+func TestByteSizeParse(t *testing.T) {
+	tests := []struct {
+		input string
+		valid bool
+		value uint64
+	}{
+		{" 1 ", true, 1},
+		{"3", true, 3},
+		{"1", true, 1},
+		{"1000", true, 1000},
+		{"1024", true, 1024},
+		{"1 kb", true, 1000},
+		{"1 kib", true, 1024},
+		{"2kb", true, 2000},
+		{"1kb man", false, 0},
+		{"1k", true, 1000},
+		{"1kb ", true, 1000},
+		{"1kb man", false, 0},
+		{" 1 kib", true, 1024},
+		{"kb", false, 0},
+		{"1e10 gb", false, 0},
+	}
+
+	for idx, test := range tests {
+		b := ByteSize(test.input)
+
+		v, err := b.Bytes()
+		if test.valid {
+			if err != nil {
+				t.Errorf("Test %d, Bytes(%s) returned unexpected error: %v", idx, test.input, err)
+			}
+		} else {
+			if err == nil {
+				t.Errorf("Test %d, Bytes(%s) expected error, but received nil.", idx, test.input)
+			}
+		}
+		if v != test.value {
+			t.Errorf("Test %d, Bytes(%s): Expected %v, got %v\n", idx, test.input, test.value, v)
+		}
+	}
+}

--- a/bytesize_test.go
+++ b/bytesize_test.go
@@ -25,6 +25,7 @@ func TestByteSizeParse(t *testing.T) {
 		{" 1 kib", true, 1024},
 		{"kb", false, 0},
 		{"1e10 gb", false, 0},
+		{"1 egg", false, 0},
 	}
 
 	for idx, test := range tests {
@@ -42,6 +43,27 @@ func TestByteSizeParse(t *testing.T) {
 		}
 		if v != test.value {
 			t.Errorf("Test %d, Bytes(%s): Expected %v, got %v\n", idx, test.input, test.value, v)
+		}
+	}
+}
+
+func TestByteSize__UnknownByteSizeUnitError(t *testing.T) {
+	tests := []struct {
+		input   string
+		checker func(err error) bool
+	}{
+		{"1 egg", IsUnknownByteSizeUnit},
+		{"dog", IsInvalidByteSizeFormatNoDigits},
+		{"dog 2", IsInvalidByteSizeFormatNoDigits},
+		{"100 little elefants", IsInvalidByteSizeFormatUnexpectedToken},
+	}
+
+	for idx, test := range tests {
+		_, err := ByteSize(test.input).Bytes()
+		if err == nil {
+			t.Errorf("Test %d: Expected error for input '%s'", idx, test.input)
+		} else if !test.checker(err) {
+			t.Errorf("Test %d: Expected checker to return true, for input '%s'. Error is '%v'", idx, test.input, err)
 		}
 	}
 }

--- a/bytesize_test.go
+++ b/bytesize_test.go
@@ -67,3 +67,12 @@ func TestByteSize__UnknownByteSizeUnitError(t *testing.T) {
 		}
 	}
 }
+
+func TestByteSize__Equals(t *testing.T) {
+	b1 := ByteSize("1 mb")
+	b2 := ByteSize("1m")
+
+	if !b1.Equals(b2) {
+		t.Fatalf("Expected '%s' and '%s' to be equal.", b1, b2)
+	}
+}

--- a/bytesize_test.go
+++ b/bytesize_test.go
@@ -26,6 +26,8 @@ func TestByteSizeParse(t *testing.T) {
 		{"kb", false, 0},
 		{"1e10 gb", false, 0},
 		{"1 egg", false, 0},
+		{"10 KiB", true, 10240},
+		{"1 GB", true, 1000 * 1000 * 1000},
 	}
 
 	for idx, test := range tests {

--- a/component_definition.go
+++ b/component_definition.go
@@ -37,6 +37,8 @@ type ComponentDefinition struct {
 	// If true, user needs to send a signal to indicate that the container is ready is should be considered running.
 	SignalReady bool `json:"signal-ready,omitempty" description:"If true, user has to notify when the component is ready."`
 
+	MemoryLimit ByteSize `json:"memory-limit,omitempty" description:"How much memory to give the container."`
+
 	// NOTE: In case we add new fields to the component definition, we need to
 	// implement proper diff functionality for those new fields as well.
 }

--- a/component_definition.go
+++ b/component_definition.go
@@ -59,21 +59,24 @@ func (nd *ComponentDefinition) validate(valCtx *ValidationContext) error {
 			return mask(InvalidMemoryLimitError)
 		}
 
-		min, err := valCtx.MinMemoryLimit.Bytes()
-		if err != nil {
-			panic("Provided minimum memory-limit is invalid: " + err.Error())
-		}
-		max, err := valCtx.MaxMemoryLimit.Bytes()
-		if err != nil {
-			panic("Provided maximum memory-limit is invalid: " + err.Error())
+		if valCtx != nil {
+			min, err := valCtx.MinMemoryLimit.Bytes()
+			if err != nil {
+				panic("Provided minimum memory-limit is invalid: " + err.Error())
+			}
+			max, err := valCtx.MaxMemoryLimit.Bytes()
+			if err != nil {
+				panic("Provided maximum memory-limit is invalid: " + err.Error())
+			}
+
+			if value < min {
+				return maskf(InvalidMemoryLimitError, "memory-limit must be above %s", valCtx.MinMemoryLimit.String())
+			}
+			if value > max {
+				return maskf(InvalidMemoryLimitError, "memory-limit must be below %s", valCtx.MaxMemoryLimit.String())
+			}
 		}
 
-		if value < min {
-			return maskf(InvalidMemoryLimitError, "memory-limit must be above %s", valCtx.MinMemoryLimit.String())
-		}
-		if value > max {
-			return maskf(InvalidMemoryLimitError, "memory-limit must be below %s", valCtx.MaxMemoryLimit.String())
-		}
 	}
 
 	if err := nd.Ports.Validate(valCtx); err != nil {

--- a/component_definition.go
+++ b/component_definition.go
@@ -53,6 +53,29 @@ func (nd *ComponentDefinition) validate(valCtx *ValidationContext) error {
 		}
 	}
 
+	if !nd.MemoryLimit.IsEmpty() {
+		value, err := nd.MemoryLimit.Bytes()
+		if err != nil {
+			return mask(InvalidMemoryLimitError)
+		}
+
+		min, err := valCtx.MinMemoryLimit.Bytes()
+		if err != nil {
+			panic("Provided minimum memory-limit is invalid: " + err.Error())
+		}
+		max, err := valCtx.MaxMemoryLimit.Bytes()
+		if err != nil {
+			panic("Provided maximum memory-limit is invalid: " + err.Error())
+		}
+
+		if value < min {
+			return maskf(InvalidMemoryLimitError, "memory-limit must be above %s", valCtx.MinMemoryLimit.String())
+		}
+		if value > max {
+			return maskf(InvalidMemoryLimitError, "memory-limit must be below %s", valCtx.MaxMemoryLimit.String())
+		}
+	}
+
 	if err := nd.Ports.Validate(valCtx); err != nil {
 		return mask(err)
 	}

--- a/component_definition.go
+++ b/component_definition.go
@@ -37,7 +37,8 @@ type ComponentDefinition struct {
 	// If true, user needs to send a signal to indicate that the container is ready is should be considered running.
 	SignalReady bool `json:"signal-ready,omitempty" description:"If true, user has to notify when the component is ready."`
 
-	MemoryLimit ByteSize `json:"memory-limit,omitempty" description:"How much memory to give the container."`
+	// How much memory to give the container. If empty, the server may decide on a default limit.
+	MemoryLimit ByteSize `json:"memory-limit,omitempty" description:"How much memory to give the container. If empty, the server may decide on a default limit."`
 
 	// NOTE: In case we add new fields to the component definition, we need to
 	// implement proper diff functionality for those new fields as well.

--- a/diff.go
+++ b/diff.go
@@ -62,6 +62,9 @@ const (
 
 	// DiffTypeComponentSignalReadyUpdated
 	DiffTypeComponentSignalReadyUpdated DiffType = "component-signal-ready-updated"
+
+	// DiffTypeComponentMemoryLimitUpdated
+	DiffTypeComponentMemoryLimitUpdated DiffType = "component-memory-limit-updated"
 )
 
 type DiffInfo struct {
@@ -248,8 +251,22 @@ func ComponentDiff(oldDef, newDef ComponentDefinition, componentName ComponentNa
 	diffInfos = append(diffInfos, diffComponentPod(oldDef, newDef, componentName)...)
 	diffInfos = append(diffInfos, diffComponentSignalReady(oldDef, newDef, componentName)...)
 	diffInfos = append(diffInfos, diffComponentScale(oldDef, newDef, componentName)...)
+	diffInfos = append(diffInfos, diffComponentMemoryLimit(oldDef, newDef, componentName)...)
 
 	return diffInfos
+}
+
+func diffComponentMemoryLimit(oldDef, newDef ComponentDefinition, componentName ComponentName) DiffInfos {
+	if oldDef.MemoryLimit != newDef.MemoryLimit {
+		return DiffInfos{DiffInfo{
+			Type:      DiffTypeComponentMemoryLimitUpdated,
+			Key:       "memory-limit",
+			Component: componentName,
+			Old:       oldDef.MemoryLimit.String(),
+			New:       newDef.MemoryLimit.String(),
+		}}
+	}
+	return DiffInfos{}
 }
 
 func diffComponentImage(oldDef, newDef ComponentDefinition, componentName ComponentName) DiffInfos {

--- a/diff_test.go
+++ b/diff_test.go
@@ -93,6 +93,31 @@ func TestDiffComponentRemoved(t *testing.T) {
 	testDiffCallWith(t, oldDef, newDef, expectedDiffInfos)
 }
 
+func TestDiffComponentMemoryLimitUpdated(t *testing.T) {
+	oldDef := V2ExampleDefinition()
+	oldDef.Components[ComponentName("my-component")] = &ComponentDefinition{
+		Image:       MustParseImageDefinition("registry.giantswarm.io/landingpage:0.10.0"),
+		MemoryLimit: ByteSize("1 gb"),
+	}
+	newDef := V2ExampleDefinition()
+	newDef.Components[ComponentName("my-component")] = &ComponentDefinition{
+		Image:       MustParseImageDefinition("registry.giantswarm.io/landingpage:0.10.0"),
+		MemoryLimit: ByteSize("12 gb"),
+	}
+
+	expectedDiffInfos := DiffInfos{
+		DiffInfo{
+			Type:      DiffTypeComponentMemoryLimitUpdated,
+			Component: "my-component",
+			Key:       "memory-limit",
+			Old:       "1 gb",
+			New:       "12 gb",
+		},
+	}
+
+	testDiffCallWith(t, oldDef, newDef, expectedDiffInfos)
+}
+
 func TestDiffComponentAddedAndRemoved(t *testing.T) {
 	oldDef := V2ExampleDefinition()
 	oldDef.Components[ComponentName("my-old-component")] = &ComponentDefinition{

--- a/diff_test.go
+++ b/diff_test.go
@@ -118,6 +118,31 @@ func TestDiffComponentMemoryLimitUpdated(t *testing.T) {
 	testDiffCallWith(t, oldDef, newDef, expectedDiffInfos)
 }
 
+func TestDiffComponentMemoryLimitUpdated__Added(t *testing.T) {
+	oldDef := V2ExampleDefinition()
+	oldDef.Components[ComponentName("my-component")] = &ComponentDefinition{
+		Image: MustParseImageDefinition("registry.giantswarm.io/landingpage:0.10.0"),
+		// NOTE: No ByteSize
+	}
+	newDef := V2ExampleDefinition()
+	newDef.Components[ComponentName("my-component")] = &ComponentDefinition{
+		Image:       MustParseImageDefinition("registry.giantswarm.io/landingpage:0.10.0"),
+		MemoryLimit: ByteSize("12 gb"),
+	}
+
+	expectedDiffInfos := DiffInfos{
+		DiffInfo{
+			Type:      DiffTypeComponentMemoryLimitUpdated,
+			Component: "my-component",
+			Key:       "memory-limit",
+			Old:       "",
+			New:       "12 gb",
+		},
+	}
+
+	testDiffCallWith(t, oldDef, newDef, expectedDiffInfos)
+}
+
 func TestDiffComponentAddedAndRemoved(t *testing.T) {
 	oldDef := V2ExampleDefinition()
 	oldDef.Components[ComponentName("my-old-component")] = &ComponentDefinition{

--- a/error.go
+++ b/error.go
@@ -33,6 +33,7 @@ var (
 	VolumeCycleError                = errgo.New("cycle detected in volume configuration")
 	WrongDiffOrderError             = errgo.New("wrong diff order")
 	LinkCycleError                  = errgo.New("cycle detected in link definition")
+	InvalidMemoryLimitError         = errgo.New("Invalid 'memory-limit' field")
 
 	mask = errgo.MaskFunc(IsInvalidEnvListFormat,
 		IsUnknownJsonField,
@@ -61,6 +62,7 @@ var (
 		IsInvalidArgument,
 		IsSyntax,
 		IsLinkCycle,
+		IsInvalidMemoryLimitError,
 	)
 
 	maskAny = errgo.MaskFunc(errgo.Any)
@@ -75,6 +77,10 @@ func maskf(cause error, f string, a ...interface{}) error {
 		e.SetLocation(1)
 	}
 	return err
+}
+
+func IsInvalidMemoryLimitError(err error) bool {
+	return errgo.Cause(err) == InvalidMemoryLimitError
 }
 
 func IsUnknownJsonField(err error) bool {

--- a/v2_user_config.go
+++ b/v2_user_config.go
@@ -58,6 +58,9 @@ type ValidationContext struct {
 	MinVolumeSize VolumeSize
 	MaxVolumeSize VolumeSize
 
+	MinMemoryLimit ByteSize
+	MaxMemoryLimit ByteSize
+
 	PublicDockerRegistry  string
 	PrivateDockerRegistry string
 }

--- a/v2_user_config.go
+++ b/v2_user_config.go
@@ -58,8 +58,9 @@ type ValidationContext struct {
 	MinVolumeSize VolumeSize
 	MaxVolumeSize VolumeSize
 
-	MinMemoryLimit ByteSize
-	MaxMemoryLimit ByteSize
+	EnableUserMemoryLimit bool // If false, the component definition MUST NOT have a memory-limit configured
+	MinMemoryLimit        ByteSize
+	MaxMemoryLimit        ByteSize
 
 	PublicDockerRegistry  string
 	PrivateDockerRegistry string


### PR DESCRIPTION
Epic: https://github.com/giantswarm/giantswarm/issues/264

Other PRs: https://github.com/giantswarm/app-service/pull/580, https://github.com/giantswarm/cli/pull/448

This PR adds a new field `memory-limit`. To enable the user to freely define different units (unlike our VolumeSize), I added a new type `ByteSize` which is more generic and can be used with any size-unit.

I also added the diff fields. Thanks for the comment in the struct ;)