### PR TITLE
All defs per pod fix

### DIFF
--- a/component_definitions.go
+++ b/component_definitions.go
@@ -438,7 +438,6 @@ func (nds *ComponentDefinitions) getIndexFromLinks(def ComponentDefinitions, def
 			if err != nil {
 				// linked-to component is not in our lists, so we don't have to care about it
 				continue
-				//return 0, maskAny(errgo.WithCausef(nil, ComponentNotFoundError, "unknown component: %s in definitions list", implName))
 			}
 
 			if implDefIndex > newIndex {

--- a/component_definitions.go
+++ b/component_definitions.go
@@ -1,9 +1,5 @@
 package userconfig
 
-import (
-	"github.com/juju/errgo"
-)
-
 type ComponentDefinitions map[ComponentName]*ComponentDefinition
 
 func (nds ComponentDefinitions) validate(valCtx *ValidationContext) error {

--- a/component_definitions.go
+++ b/component_definitions.go
@@ -440,7 +440,9 @@ func (nds *ComponentDefinitions) getIndexFromLinks(def ComponentDefinitions, def
 			// Find implementation component
 			implDefIndex, err := indexOf(implName)
 			if err != nil {
-				return 0, maskAny(errgo.WithCausef(nil, ComponentNotFoundError, "unknown component: %s in definitions list", implName))
+				// linked-to component is not in our lists, so we don't have to care about it
+				continue
+				//return 0, maskAny(errgo.WithCausef(nil, ComponentNotFoundError, "unknown component: %s in definitions list", implName))
 			}
 
 			if implDefIndex > newIndex {

--- a/component_definitions_test.go
+++ b/component_definitions_test.go
@@ -104,7 +104,7 @@ func Test_AllDefsPerPod_Sorting_NotAllNames(t *testing.T) {
 	}
 
 	// Component "box" links to component "dep", no pods involved, we only ask for "box"
-	// Therefore we expect to get 1 maps from AllDefsPerPod, the containing 'box'.
+	// Therefore we expect to get 1 map from AllDefsPerPod, containing 'box'.
 	// No error is allowed.
 	def.Components["dep"] = testComponent()
 	def.Components["box"] = testComponent()

--- a/component_definitions_test.go
+++ b/component_definitions_test.go
@@ -103,8 +103,9 @@ func Test_AllDefsPerPod_Sorting_NotAllNames(t *testing.T) {
 		Components: userconfig.ComponentDefinitions{},
 	}
 
-	// Component "a" links to component "b", no pods involved
-	// Therefore we expect to get 2 maps from AllDefsPerPod, the first containing 'b', the second containing 'a'
+	// Component "box" links to component "dep", no pods involved, we only ask for "box"
+	// Therefore we expect to get 1 maps from AllDefsPerPod, the containing 'box'.
+	// No error is allowed.
 	def.Components["dep"] = testComponent()
 	def.Components["box"] = testComponent()
 	def.Components["dep"].Ports = userconfig.PortDefinitions{


### PR DESCRIPTION
This change fixes an error in the `AllDefsPerPod` functions that is triggered when calling it with:

- component definitions: `[box, def] (assuming that box links to def)`
- names [box]

The original code failed because if could not found `def` during sorting.
Since `def` is not supposed to be there, this was change to `continue`.