### PR TITLE
Allow more than one public/private registry

### DIFF
--- a/image.go
+++ b/image.go
@@ -31,5 +31,10 @@ func (id ImageDefinition) Validate(valCtx *ValidationContext) error {
 }
 
 func (id ImageDefinition) isGSRegistry(valCtx *ValidationContext) bool {
-	return id.Registry == valCtx.PublicDockerRegistry || id.Registry == valCtx.PrivateDockerRegistry
+	for _, registry := range valCtx.RestrictedRegistries {
+		if id.Registry == registry {
+			return true
+		}
+	}
+	return false
 }

--- a/image_test.go
+++ b/image_test.go
@@ -29,9 +29,11 @@ func TestTypeAssertDockerImage(t *testing.T) {
 
 func TestImageValidOrgWithPublicRegistry(t *testing.T) {
 	valCtx := &userconfig.ValidationContext{
-		Org:                   "myorg",
-		PublicDockerRegistry:  "registry.giantswarm.io",
-		PrivateDockerRegistry: "registry.private.giantswarm.io",
+		Org: "myorg",
+		RestrictedRegistries: []string{
+			"registry.giantswarm.io",
+			"registry.private.giantswarm.io",
+		},
 	}
 
 	id := userconfig.MustParseImageDefinition("registry.giantswarm.io/myorg/foo")
@@ -44,9 +46,11 @@ func TestImageValidOrgWithPublicRegistry(t *testing.T) {
 
 func TestImageValidOrgWithPrivateRegistry(t *testing.T) {
 	valCtx := &userconfig.ValidationContext{
-		Org:                   "myorg",
-		PublicDockerRegistry:  "registry.giantswarm.io",
-		PrivateDockerRegistry: "registry.private.giantswarm.io",
+		Org: "myorg",
+		RestrictedRegistries: []string{
+			"registry.giantswarm.io",
+			"registry.private.giantswarm.io",
+		},
 	}
 
 	id := userconfig.MustParseImageDefinition("registry.private.giantswarm.io/myorg/foo")
@@ -59,9 +63,11 @@ func TestImageValidOrgWithPrivateRegistry(t *testing.T) {
 
 func TestImageInvalidOrgWithPublicRegistry(t *testing.T) {
 	valCtx := &userconfig.ValidationContext{
-		Org:                   "myorg",
-		PublicDockerRegistry:  "registry.giantswarm.io",
-		PrivateDockerRegistry: "registry.private.giantswarm.io",
+		Org: "myorg",
+		RestrictedRegistries: []string{
+			"registry.giantswarm.io",
+			"registry.private.giantswarm.io",
+		},
 	}
 
 	id := userconfig.MustParseImageDefinition("registry.giantswarm.io/otherorg/foo")
@@ -77,9 +83,11 @@ func TestImageInvalidOrgWithPublicRegistry(t *testing.T) {
 
 func TestImageInvalidOrgWithPrivateRegistry(t *testing.T) {
 	valCtx := &userconfig.ValidationContext{
-		Org:                   "myorg",
-		PublicDockerRegistry:  "registry.giantswarm.io",
-		PrivateDockerRegistry: "registry.private.giantswarm.io",
+		Org: "myorg",
+		RestrictedRegistries: []string{
+			"registry.giantswarm.io",
+			"registry.private.giantswarm.io",
+		},
 	}
 
 	id := userconfig.MustParseImageDefinition("registry.private.giantswarm.io/otherorg/foo")

--- a/service_definition.go
+++ b/service_definition.go
@@ -72,8 +72,9 @@ type ValidationContext struct {
 	MinMemoryLimit        ByteSize
 	MaxMemoryLimit        ByteSize
 
-	PublicDockerRegistry  string
-	PrivateDockerRegistry string
+	// RestrictedRegistries contains the registry names, where the validator should throw an error, if the repository
+	// namespace does not contain the Org
+	RestrictedRegistries []string
 }
 
 // validate performs semantic validations of this ServiceDefinition.


### PR DESCRIPTION
Parent: https://github.com/giantswarm/app-service/pull/701

On leaseweb we now need to support multiple domain names (registry + registry02).

This PR allows this by changing the image validation logic to just accept a list of registries instead of a public + private one.

* cli is not using this logic
* appd: A PR will be prepared